### PR TITLE
feature: Add logger for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,10 @@ EOF
   write_all_buffers = false, -- write all buffers when the current one meets `condition`
   debounce_delay = 1000, -- delay after which a pending save is executed
   callbacks = { -- functions to be executed at different intervals
-    enabling = nil, -- ran when enabling auto-save
-    disabling = nil, -- ran when disabling auto-save
     before_saving = nil, -- ran before doing the actual save
-    after_saving = nil -- ran after doing the actual save
-  }
+  },
+ -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
+  debug = false,
 }
 ```
 

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -22,11 +22,10 @@ Config = {
     write_all_buffers = false, -- write all buffers when the current one meets `condition`
     debounce_delay = 1000, -- delay after which a pending save is executed
     callbacks = { -- functions to be executed at different intervals
-      enabling = nil, -- ran when enabling auto-save
-      disabling = nil, -- ran when disabling auto-save
       before_saving = nil, -- ran before doing the actual save
-      after_saving = nil, -- ran after doing the actual save
     },
+    -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
+    debug = false, -- print debug messages, set to `true` to enable
   },
 }
 

--- a/lua/auto-save/utils/logging.lua
+++ b/lua/auto-save/utils/logging.lua
@@ -1,0 +1,42 @@
+-- inspired from https://github.com/nvim-lua/plenary.nvim/blob/master/lua/plenary/log.lua
+
+local M = {}
+
+local outfile = string.format("%s/auto-save.log", vim.api.nvim_call_function("stdpath", { "cache" }))
+
+-- it could be that the directory of the file does not exist
+-- this would require further checks, see https://github.com/nvim-lua/plenary.nvim/blob/master/lua/plenary/log.lua#L138
+--- @param message string
+local write_to_outfile = function(message)
+  local f = assert(io.open(outfile, "a"))
+  f:write(message)
+  f:close()
+end
+
+M.new = function(options)
+  local enabled = options.debug
+
+  --- @param buf number | nil
+  --- @param message string
+  local log = function(buf, message)
+    if not enabled then
+      return
+    end
+
+    local log_message
+    if buf ~= nil then
+      local filename = vim.api.nvim_buf_get_name(buf)
+      log_message = string.format("[%s] [%s] - %s\n", os.date(), filename, message)
+    else
+      log_message = string.format("[%s] - %s\n", os.date(), message)
+    end
+
+    write_to_outfile(log_message)
+  end
+
+  return {
+    log = log,
+  }
+end
+
+return M


### PR DESCRIPTION
Fixes #13 

It's tested and good to go :)
Tell me if you would like to have more places for the logging.
I had it in the autocommands at first, but this was to much noise. Also I don't see the reason in having them in the `on` and `off` methods, since they are echoed out to the user anyways.

Ideas for the logger implementation came mostly from `plenary.nvim`

If we want to get even fancier with the logger (checking if `.cache/nvim` directory exists, different log levels, etc.) we might just use their implementation.