### PR TITLE
ci: fix stylua workflow

### DIFF
--- a/.github/workflows/stylua.yml
+++ b/.github/workflows/stylua.yml
@@ -1,7 +1,7 @@
 on:
-  pull_request:
-    branches:
-      - main
+  pull_request_target:
+    paths:
+      - "**.lua"
 
 jobs:
   stylua:


### PR DESCRIPTION
Workflow was broken for everybody except me since pull_request trigger only works properly if every contributor has write access to the repo. With fork based workflow prevalent in Github the trigger to use is pull_request_target where the config and access token comes from main branch instead of the PR itself.

Other notable changes:
- Only run checks if lua files change
- Run even if PR targets some branch other than main