### PR TITLE
fix: dim would not get applied when lazy loading plugin

### DIFF
--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -1,8 +1,10 @@
+--- @class Config
 Config = {
   opts = {
     enabled = true, -- start auto-save when the plugin is loaded (i.e. when your package manager loads it)
     execution_message = {
       enabled = true,
+      --- @type string|fun(): string
       message = function() -- message to print on save
         return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
       end,
@@ -18,6 +20,7 @@ Config = {
     -- return true: if buffer is ok to be saved
     -- return false: if it's not ok to be saved
     -- if set to `nil` then no specific condition is applied
+    --- @type nil|fun(buf: number): boolean
     condition = nil,
     write_all_buffers = false, -- write all buffers when the current one meets `condition`
     debounce_delay = 1000, -- delay after which a pending save is executed

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -46,6 +46,7 @@ end
 local function echo_execution_message()
   local message = cnf.opts.execution_message.message
   local msg = type(message) == "function" and message() or message
+  ---@diagnostic disable-next-line: deprecated
   colors.echo_with_highlight(msg --[[@as string]])
   if cnf.opts.execution_message.cleaning_interval > 0 then
     fn.timer_start(cnf.opts.execution_message.cleaning_interval, function()
@@ -145,6 +146,7 @@ function M.on()
   local function setup_dimming()
     if cnf.opts.execution_message.enabled then
       schedule(function()
+        ---@diagnostic disable-next-line: deprecated
         colors.apply_colors(cnf.opts.execution_message.dim)
       end)
     end

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -142,7 +142,7 @@ function M.on()
     desc = "Cancel a pending save timer for a buffer",
   })
 
-  local function dim()
+  local function setup_dimming()
     if cnf.opts.execution_message.enabled then
       schedule(function()
         colors.apply_colors(cnf.opts.execution_message.dim)
@@ -150,10 +150,10 @@ function M.on()
     end
   end
 
-  dim()
+  setup_dimming()
   api.nvim_create_autocmd("ColorScheme", {
     callback = function()
-      dim()
+      setup_dimming()
     end,
     group = augroup,
   })

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -1,18 +1,18 @@
 local M = {}
 
+--- @class Config
 local cnf = require("auto-save.config")
 local colors = require("auto-save.utils.colors")
 local echo = require("auto-save.utils.echo")
 local autocmds = require("auto-save.utils.autocommands")
-local logger
-local autosave_running
+
 local api = vim.api
 local fn = vim.fn
 local cmd = vim.cmd
-local o = vim.o
-local AUTO_SAVE_COLOR = "MsgArea"
-local BLACK = "#000000"
-local WHITE = "#ffffff"
+local schedule = vim.schedule
+
+local logger
+local autosave_running
 
 autocmds.create_augroup({ clear = true })
 
@@ -44,9 +44,9 @@ local function debounce(lfn, duration)
 end
 
 local function echo_execution_message()
-  local msg = type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message()
-    or cnf.opts.execution_message.message
-  api.nvim_echo({ { msg, AUTO_SAVE_COLOR } }, true, {})
+  local message = cnf.opts.execution_message.message
+  local msg = type(message) == "function" and message() or message
+  colors.echo_with_highlight(msg --[[@as string]])
   if cnf.opts.execution_message.cleaning_interval > 0 then
     fn.timer_start(cnf.opts.execution_message.cleaning_interval, function()
       cmd([[echon '']])
@@ -142,32 +142,18 @@ function M.on()
     desc = "Cancel a pending save timer for a buffer",
   })
 
-  api.nvim_create_autocmd({ "VimEnter", "ColorScheme", "UIEnter" }, {
-    callback = function()
-      vim.schedule(function()
-        if cnf.opts.execution_message.dim > 0 then
-          MSG_AREA = colors.get_hl("MsgArea")
-          if MSG_AREA.foreground ~= nil then
-            MSG_AREA.background = (MSG_AREA.background or colors.get_hl("Normal")["background"])
-            local foreground = (
-              o.background == "dark"
-                and colors.darken(
-                  (MSG_AREA.background or BLACK),
-                  cnf.opts.execution_message.dim,
-                  MSG_AREA.foreground or BLACK
-                )
-              or colors.lighten(
-                (MSG_AREA.background or WHITE),
-                cnf.opts.execution_message.dim,
-                MSG_AREA.foreground or WHITE
-              )
-            )
-
-            colors.highlight("AutoSaveText", { fg = foreground })
-            AUTO_SAVE_COLOR = "AutoSaveText"
-          end
-        end
+  local function dim()
+    if cnf.opts.execution_message.enabled then
+      schedule(function()
+        colors.apply_colors(cnf.opts.execution_message.dim)
       end)
+    end
+  end
+
+  dim()
+  api.nvim_create_autocmd("ColorScheme", {
+    callback = function()
+      dim()
     end,
     group = augroup,
   })

--- a/lua/auto-save/utils/colors.lua
+++ b/lua/auto-save/utils/colors.lua
@@ -1,4 +1,13 @@
+local o = vim.o
+local api = vim.api
+
+local BLACK = "#000000"
+local WHITE = "#ffffff"
+local auto_save_hl_group = "MsgArea"
+
 local M = {}
+
+
 ---@param hex_str string hexadecimal value of a color
 local hex_to_rgb = function(hex_str)
   local hex = "[abcdef0-9][abcdef0-9]"
@@ -11,7 +20,10 @@ local hex_to_rgb = function(hex_str)
   return { tonumber(red, 16), tonumber(green, 16), tonumber(blue, 16) }
 end
 
-function M.highlight(group, color, force)
+--- @param group string
+--- @param color table
+--- @param force? boolean
+local function highlight(group, color, force)
   if color.link then
     vim.api.nvim_set_hl(0, group, {
       link = color.link,
@@ -31,7 +43,7 @@ function M.highlight(group, color, force)
   end
 end
 
-function M.get_hl(name)
+local function get_hl(name)
   local ok, hl = pcall(vim.api.nvim_get_hl_by_name, name, true)
   if not ok then
     return
@@ -44,27 +56,42 @@ function M.get_hl(name)
   return hl
 end
 
----@param fg string forecrust color
+---@param fg string foreground color
 ---@param bg string background color
 ---@param alpha number number between 0 and 1. 0 results in bg, 1 results in fg
-function M.blend(fg, bg, alpha)
-  bg = hex_to_rgb(bg)
-  fg = hex_to_rgb(fg)
+local function blend(fg, bg, alpha)
+  local bg_hex = hex_to_rgb(bg)
+  local fg_hex = hex_to_rgb(fg)
 
   local blendChannel = function(i)
-    local ret = (alpha * fg[i] + ((1 - alpha) * bg[i]))
+    local ret = (alpha * fg_hex[i] + ((1 - alpha) * bg_hex[i]))
     return math.floor(math.min(math.max(0, ret), 255) + 0.5)
   end
 
   return string.format("#%02X%02X%02X", blendChannel(1), blendChannel(2), blendChannel(3))
 end
 
-function M.darken(hex, amount, bg)
-  return M.blend(hex, bg or M.bg, math.abs(amount))
+--- @param dim_value number
+M.apply_colors = function(dim_value)
+    if dim_value > 0 then
+      MSG_AREA = get_hl("MsgArea")
+      if MSG_AREA.foreground ~= nil then
+        MSG_AREA.background = (MSG_AREA.background or get_hl("Normal")["background"])
+        -- TODO maybe there is a hiccup here, test a bit
+        local foreground = (
+          o.background == "dark" and blend((MSG_AREA.background or BLACK), MSG_AREA.foreground or BLACK, dim_value)
+          or blend((MSG_AREA.background or WHITE), MSG_AREA.foreground or WHITE, dim_value)
+        )
+
+        highlight("AutoSaveText", { fg = foreground })
+        auto_save_hl_group = "AutoSaveText"
+      end
+    end
 end
 
-function M.lighten(hex, amount, fg)
-  return M.blend(hex, fg or M.fg, math.abs(amount))
+--- @param message string
+M.echo_with_highlight = function(message)
+  api.nvim_echo({ { message, auto_save_hl_group } }, true, {})
 end
 
 return M

--- a/lua/auto-save/utils/colors.lua
+++ b/lua/auto-save/utils/colors.lua
@@ -1,3 +1,6 @@
+--- This file is deprecated and should be removed in the future.
+--- It is still in use but the functionality does not belong in the scope of this plugin
+
 local o = vim.o
 local api = vim.api
 
@@ -70,6 +73,9 @@ local function blend(fg, bg, alpha)
   return string.format("#%02X%02X%02X", blendChannel(1), blendChannel(2), blendChannel(3))
 end
 
+--- This function is still in use, but should be removed in the future.
+--- The dimming should be done by the colorscheme or an UI Plugin.
+--- @deprecated
 --- @param dim_value number
 M.apply_colors = function(dim_value)
   if dim_value > 0 then
@@ -87,6 +93,8 @@ M.apply_colors = function(dim_value)
   end
 end
 
+--- @deprecated
+--- @see M.apply_colors
 --- @param message string
 M.echo_with_highlight = function(message)
   api.nvim_echo({ { message, auto_save_hl_group } }, true, {})

--- a/lua/auto-save/utils/colors.lua
+++ b/lua/auto-save/utils/colors.lua
@@ -7,7 +7,6 @@ local auto_save_hl_group = "MsgArea"
 
 local M = {}
 
-
 ---@param hex_str string hexadecimal value of a color
 local hex_to_rgb = function(hex_str)
   local hex = "[abcdef0-9][abcdef0-9]"
@@ -73,20 +72,19 @@ end
 
 --- @param dim_value number
 M.apply_colors = function(dim_value)
-    if dim_value > 0 then
-      MSG_AREA = get_hl("MsgArea")
-      if MSG_AREA.foreground ~= nil then
-        MSG_AREA.background = (MSG_AREA.background or get_hl("Normal")["background"])
-        -- TODO maybe there is a hiccup here, test a bit
-        local foreground = (
-          o.background == "dark" and blend((MSG_AREA.background or BLACK), MSG_AREA.foreground or BLACK, dim_value)
-          or blend((MSG_AREA.background or WHITE), MSG_AREA.foreground or WHITE, dim_value)
-        )
+  if dim_value > 0 then
+    MSG_AREA = get_hl("MsgArea")
+    if MSG_AREA.foreground ~= nil then
+      MSG_AREA.background = (MSG_AREA.background or get_hl("Normal")["background"])
+      local foreground = (
+        o.background == "dark" and blend(MSG_AREA.background or BLACK, MSG_AREA.foreground or BLACK, dim_value)
+        or blend(MSG_AREA.background or WHITE, MSG_AREA.foreground or WHITE, dim_value)
+      )
 
-        highlight("AutoSaveText", { fg = foreground })
-        auto_save_hl_group = "AutoSaveText"
-      end
+      highlight("AutoSaveText", { fg = foreground })
+      auto_save_hl_group = "AutoSaveText"
     end
+  end
 end
 
 --- @param message string


### PR DESCRIPTION
Fixes #26

- Dim is now getting applied when plugin is turned on, as well as when the colorscheme is changed
- Only apply dim if execution message is enabled
- Moved the color logic out of `init.lua`, into `colors.lua`
- Added some types 