### PR TITLE
fix: disabling autosave wouldn't work

### DIFF
--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -112,7 +112,7 @@ local function defer_save(buf)
 end
 
 function M.on()
-  local augroup = autocmds.create_augroup()
+  local augroup = autocmds.create_augroup({ clear = true })
 
   api.nvim_create_autocmd(cnf.opts.trigger_events.immediate_save, {
     callback = function(opts)

--- a/lua/auto-save/utils/autocommands.lua
+++ b/lua/auto-save/utils/autocommands.lua
@@ -4,9 +4,10 @@ local api = vim.api
 local augroup_name = "AutoSave"
 
 --- @param opts? table
+--- @return number
 M.create_augroup = function(opts)
-  opts = opts or {}
-  api.nvim_create_augroup(augroup_name, opts)
+  opts = opts or { clear = true }
+  return api.nvim_create_augroup(augroup_name, opts)
 end
 
 --- @param pattern string


### PR DESCRIPTION
I forgot to add a return statement to the created autogroup. That lead to the autogroup never being cleared when turning auto-save off.

It's a little embarassing :D

The changes to the `opts` argument don't change anything, I just think they look nicer ;-)