### PR TITLE
fix: Empty `trigger_events` crash the plugin

### DIFF
--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -12,8 +12,11 @@ Config = {
       cleaning_interval = 1250, -- (milliseconds) automatically clean MsgArea after displaying `message`. See :h MsgArea
     },
     trigger_events = { -- See :h events
+      --- @type nil|string[]
       immediate_save = { "BufLeave", "FocusLost" }, -- vim events that trigger an immediate save
+      --- @type nil|string[]
       defer_save = { "InsertLeave", "TextChanged" }, -- vim events that trigger a deferred save (saves after `debounce_delay`)
+      --- @type nil|string[]
       cancel_defered_save = { "InsertEnter" }, -- vim events that cancel a pending deferred save
     },
     -- function that takes the buffer handle and determines whether to save the current buffer or not

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -115,33 +115,41 @@ end
 function M.on()
   local augroup = autocmds.create_augroup({ clear = true })
 
-  api.nvim_create_autocmd(cnf.opts.trigger_events.immediate_save, {
-    callback = function(opts)
-      if should_be_saved(opts.buf) then
-        immediate_save(opts.buf)
-      end
-    end,
-    group = augroup,
-    desc = "Immediately save a buffer",
-  })
-  api.nvim_create_autocmd(cnf.opts.trigger_events.defer_save, {
-    callback = function(opts)
-      if should_be_saved(opts.buf) then
-        defer_save(opts.buf)
-      end
-    end,
-    group = augroup,
-    desc = "Save a buffer after the `debounce_delay`",
-  })
-  api.nvim_create_autocmd(cnf.opts.trigger_events.cancel_defered_save, {
-    callback = function(opts)
-      if should_be_saved(opts.buf) then
-        cancel_timer(opts.buf)
-      end
-    end,
-    group = augroup,
-    desc = "Cancel a pending save timer for a buffer",
-  })
+  local events = cnf.opts.trigger_events
+
+  if events.immediate_save ~= nil and #events.immediate_save > 0 then
+    api.nvim_create_autocmd(events.immediate_save, {
+      callback = function(opts)
+        if should_be_saved(opts.buf) then
+          immediate_save(opts.buf)
+        end
+      end,
+      group = augroup,
+      desc = "Immediately save a buffer",
+    })
+  end
+  if events.defer_save ~= nil and #events.defer_save > 0 then
+    api.nvim_create_autocmd(events.defer_save, {
+      callback = function(opts)
+        if should_be_saved(opts.buf) then
+          defer_save(opts.buf)
+        end
+      end,
+      group = augroup,
+      desc = "Save a buffer after the `debounce_delay`",
+    })
+  end
+  if events.cancel_defered_save ~= nil and #events.cancel_defered_save > 0 then
+    api.nvim_create_autocmd(events.cancel_defered_save, {
+      callback = function(opts)
+        if should_be_saved(opts.buf) then
+          cancel_timer(opts.buf)
+        end
+      end,
+      group = augroup,
+      desc = "Cancel a pending save timer for a buffer",
+    })
+  end
 
   local function setup_dimming()
     if cnf.opts.execution_message.enabled then


### PR DESCRIPTION
While investigating this fork: https://github.com/Learde/auto-save.nvim
I realized, that we don't safe guard empty trigger_events.
This is fixed in this PR.
