### PR TITLE
chore(doc): switch Events / Callbacks emoji

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: kdheepak/panvimdoc@v3.0.5
+      - uses: kdheepak/panvimdoc@v3.0.6
         with:
           vimdoc: auto-save.nvim
           version: "Neovim >= 0.8.0"

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ or as part of the `lazy.nvim` plugin spec:
 
 ```
 
-## 🪝 Events / Callbacks
+## ↩️  Events / Callbacks
 
 The plugin fires events at various points during its lifecycle which users can hook into:
 


### PR DESCRIPTION
Demojify used by panvimdoc to strip emojis is outdated, it doesn't include any codepoints since Unicode 12. So Hook emoji ended up in the vimdoc since it was included in Unicode 13. Switching to an older emoji is good enough a workaround for now.

Also bumped panvimdoc version.