### PR TITLE
feat: [#36] Expose `immediate_save` function

### DIFF
--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -98,7 +98,9 @@ local function save(buf)
   end
 end
 
-local function immediate_save(buf)
+--- Saves the given buffer immediately, canceling any pending timers.
+--- @param buf number
+function M.immediate_save(buf)
   cancel_timer(buf)
   save(buf)
 end
@@ -122,7 +124,7 @@ function M.on()
     api.nvim_create_autocmd(events.immediate_save, {
       callback = function(opts)
         if should_be_saved(opts.buf) then
-          immediate_save(opts.buf)
+          M.immediate_save(opts.buf)
         end
       end,
       group = augroup,


### PR DESCRIPTION
## Overview
This exposes the `immediate_save` function for outside use.

It allows us to create things like the following:

```lua
local save_before = function(callback)
  return function()
    local buf = api.nvim_get_current_buf()
    require('auto-save').immediate_save(buf)
    callback()
  end
end
```

Which can then be used like this:
```lua
vim.keymap.set('n', '<leader>rf', save_before(function() require('neotest').run.run() end)
```

## Open Questions
1. Should we put the `local buf = api.nvim_get_current_buf()` line inside of the `immediate_save` function? Or should the user be responsible for that?
