### PR TITLE
feat: GH-44 lock marks when saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ EOF
   condition = nil,
   write_all_buffers = false, -- write all buffers when the current one meets `condition`
   noautocmd = false, -- do not execute autocmds when saving
+  lockmarks = false, -- lock marks (mainly `[` and `]`) when saving
   debounce_delay = 1000, -- delay after which a pending save is executed
  -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
   debug = false,

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ EOF
   condition = nil,
   write_all_buffers = false, -- write all buffers when the current one meets `condition`
   noautocmd = false, -- do not execute autocmds when saving
-  lockmarks = false, -- lock marks (mainly `[` and `]`) when saving
+  lockmarks = false, -- lock marks when saving, see `:h lockmarks` for more details
   debounce_delay = 1000, -- delay after which a pending save is executed
  -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
   debug = false,

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -27,7 +27,7 @@ Config = {
     condition = nil,
     write_all_buffers = false, -- write all buffers when the current one meets `condition`
     noautocmd = false, -- do not execute autocmds when saving
-    lockmarks = false, -- lock marks (mainly `[` and `]`) when saving
+    lockmarks = false, -- lock marks when saving, see `:h lockmarks` for more details
     debounce_delay = 1000, -- delay after which a pending save is executed
     -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
     debug = false, -- print debug messages, set to `true` to enable

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -27,6 +27,7 @@ Config = {
     condition = nil,
     write_all_buffers = false, -- write all buffers when the current one meets `condition`
     noautocmd = false, -- do not execute autocmds when saving
+    lockmarks = false, -- lock marks (mainly `[` and `]`) when saving
     debounce_delay = 1000, -- delay after which a pending save is executed
     -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
     debug = false, -- print debug messages, set to `true` to enable

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -91,11 +91,12 @@ local function save(buf)
   autocmds.exec_autocmd("AutoSaveWritePre", { saved_buffer = buf })
 
   local noautocmd = cnf.opts.noautocmd and "noautocmd " or ""
+  local lockmarks = cnf.opts.lockmarks and "lockmarks " or ""
   if cnf.opts.write_all_buffers then
-    cmd(noautocmd .. "lockmarks silent! wall")
+    cmd(noautocmd .. lockmarks .. "silent! wall")
   else
     api.nvim_buf_call(buf, function()
-      cmd(noautocmd .. "lockmarks silent! write")
+      cmd(noautocmd .. lockmarks .. "silent! write")
     end)
   end
 

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -18,6 +18,7 @@ autocmds.create_augroup({ clear = true })
 
 local timers_by_buffer = {}
 
+--- @param buf number
 local function cancel_timer(buf)
   local timer = timers_by_buffer[buf]
   if timer ~= nil then
@@ -28,6 +29,9 @@ local function cancel_timer(buf)
   end
 end
 
+--- @param lfn fun(buf: number) The function to debounce
+--- @param duration number The debounce duration
+--- @return fun(buf: number) debounced The debounced function
 local function debounce(lfn, duration)
   local function inner_debounce(buf)
     -- instead of canceling the timer we could check if there is one already running for this buffer and restart it (`:again`)
@@ -72,6 +76,7 @@ local function should_be_saved(buf)
   return true
 end
 
+--- @param buf number
 local function save(buf)
   if not api.nvim_buf_is_loaded(buf) then
     return
@@ -87,10 +92,10 @@ local function save(buf)
 
   local noautocmd = cnf.opts.noautocmd and "noautocmd " or ""
   if cnf.opts.write_all_buffers then
-    cmd(noautocmd .. "silent! wall")
+    cmd(noautocmd .. "lockmarks silent! wall")
   else
     api.nvim_buf_call(buf, function()
-      cmd(noautocmd .. "silent! write")
+      cmd(noautocmd .. "lockmarks silent! write")
     end)
   end
 
@@ -102,12 +107,14 @@ local function save(buf)
   end
 end
 
+--- @param buf number
 local function immediate_save(buf)
   cancel_timer(buf)
   save(buf)
 end
 
 local save_func = nil
+--- @param buf number
 local function defer_save(buf)
   -- is it really needed to cache this function
   -- TODO: remove?


### PR DESCRIPTION
Use `lockmarks` in write command to keep `[` and `]` marks after saving.

Thanks @simonmandlik