### PR TITLE
fix: Do not fail on `trigger_events`’ `pattern`

### DIFF
--- a/lua/auto-save/utils/autocommands.lua
+++ b/lua/auto-save/utils/autocommands.lua
@@ -32,7 +32,7 @@ end
 --- @param trigger_events TriggerEvent[]?
 M.create_autocmd_for_trigger_events = function(trigger_events, autocmd_opts)
   if trigger_events ~= nil then
-    for _, event in pairs(trigger_events) do
+    for _, event in ipairs(trigger_events) do
       local parsed_event = parse_trigger_event(event)
       local autocmd_opts_with_pattern = vim.tbl_extend("force", autocmd_opts, { pattern = parsed_event.pattern })
       api.nvim_create_autocmd(parsed_event[1], autocmd_opts_with_pattern)


### PR DESCRIPTION
The following example configuration in the `README.md`:

```lua
{
  trigger_events = {
    immediate_save = {
      { "BufLeave", pattern = {"*.c", "*.h"} }
    }
  }
}
```

results in

```
Failed to run `config` for auto-save.nvim                                                             
                                                                                                      
...lazy/auto-save.nvim/lua/auto-save/utils/autocommands.lua:38: Invalid 'event': '*.c'                
                                                                                                      
# stacktrace:                                                                                         
  - /auto-save.nvim/lua/auto-save/utils/autocommands.lua:38 _in_ **create_autocmd_for_trigger_events**
  - /auto-save.nvim/lua/auto-save/init.lua:114 _in_ **on**                                            
  - /auto-save.nvim/lua/auto-save/init.lua:171 _in_ **setup**     
  - ~/.config/nvim/init.lua                               
```

[Neovim v0.10.2 from Arch / auto-save 5fbcaac0 with Lazy.nvim]

This commit fixes the `nvim_create_autocmd` loop to not confuse the `pattern = …` entry with an event name.