### PR TITLE
docs: update version to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Install the plugin with your favourite package manager:
 ```lua
 {
   "okuuva/auto-save.nvim",
-  version = '^1.0.0', -- see https://devhints.io/semver, alternatively use '*' to use the latest tagged release
+  version = '^1.1.0', -- see https://devhints.io/semver, alternatively use '*' to use the latest tagged release
   cmd = "ASToggle", -- optional for lazy loading on command
   event = { "InsertLeave", "TextChanged" }, -- optional for lazy loading on trigger events
   opts = {


### PR DESCRIPTION
Toogle function with **snacks.nvim** not working in **lazy.nvim** if version 1.0.0 is installed